### PR TITLE
change EmailField to CharField in RegisterSerializer

### DIFF
--- a/apps/authentication/serializers.py
+++ b/apps/authentication/serializers.py
@@ -32,7 +32,7 @@ class RegisterSerializer(DjRestAuthRegisterSerializer):
         max_length=38,
         min_length=1,
     )
-    email = serializers.EmailField(
+    email = serializers.CharField(
         required=True,
         max_length=254,
         validators=(EmailValidator(),),

--- a/apps/users/validators.py
+++ b/apps/users/validators.py
@@ -15,6 +15,8 @@ def validate_telegram_name(value):
 
 
 class EmailValidator(DjangoEmailValidator):
+    message = "Введите корректный адрес электронной почты"
+
     # https://github.com/Githance/testing/issues/11
     # Removed %|/! characters to fix sending emails via Beget SMTP server.
     # Removed regex part for quoted string validation.


### PR DESCRIPTION
Попытка номер 2 закрыть баг репорт:
- https://github.com/Githance/testing/issues/15

Изменения:
- Сменил `EmailField` на `CharField` в `RegisterSerializer`, чтобы в `EmailField` не применялся указанный в нем дефолтный `EmailValidator`. Что забыл сделать в прошлый раз.