### PR TITLE
allow setting cookie on http client from https server

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -23,9 +23,6 @@ ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", [])
 # https://pypi.org/project/django-cors-headers/
 CORS_ALLOWED_ORIGINS = env.list("DJANGO_CORS_ALLOWED_ORIGINS", [])
 
-# https://docs.djangoproject.com/en/3.2/ref/settings/#use-x-forwarded-host
-USE_X_FORWARDED_HOST = True
-
 # https://docs.djangoproject.com/en/3.2/ref/settings/#secure-proxy-ssl-header
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
@@ -228,7 +225,7 @@ SOCIALACCOUNT_PROVIDERS = {
     }
 }
 
-# custom parameter to apps.authentication.serializers.SocialLoginSerializer
+# Custom parameter to apps.authentication.serializers.SocialLoginSerializer
 ALLOW_GOOGLE_CODE_FROM_LOCALHOST_3000 = env.bool(
     "DJANGO_ALLOW_GOOGLE_CODE_FROM_LOCALHOST_3000", False
 )

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -1,3 +1,5 @@
+from corsheaders.defaults import default_headers
+
 from .base import *  # noqa: F403,F401
 
 DEBUG = True
@@ -9,6 +11,12 @@ SIMPLE_JWT.update(
         )
     }
 )
+
+# Allow setting cookie on http:// from https:// server
+CORS_ALLOW_HEADERS = [*default_headers, "credentials"]
+CORS_ALLOW_CREDENTIALS = True
+JWT_AUTH_SAMESITE = "None"
+
 
 # -------------------------------- DJANGO DEBUG TOOLBAR --------------------------------
 


### PR DESCRIPTION
- Добавлены настройки, чтобы можно было получать куки с http**s** сервера, ведя разработку фронта на локальном http.