### PR TITLE
jwt secure temporary set false

### DIFF
--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -15,7 +15,8 @@ SIMPLE_JWT.update(
 # Allow setting cookie on http:// from https:// server
 CORS_ALLOW_HEADERS = [*default_headers, "credentials"]
 CORS_ALLOW_CREDENTIALS = True
-JWT_AUTH_SAMESITE = "None"
+JWT_AUTH_SAMESITE = "Strict"
+JWT_AUTH_SECURE = False
 
 
 # -------------------------------- DJANGO DEBUG TOOLBAR --------------------------------

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -15,7 +15,7 @@ SIMPLE_JWT.update(
 # Allow setting cookie on http:// from https:// server
 CORS_ALLOW_HEADERS = [*default_headers, "credentials"]
 CORS_ALLOW_CREDENTIALS = True
-JWT_AUTH_SAMESITE = "Strict"
+JWT_AUTH_SAMESITE = None
 JWT_AUTH_SECURE = False
 
 

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -15,7 +15,7 @@ SIMPLE_JWT.update(
 # Allow setting cookie on http:// from https:// server
 CORS_ALLOW_HEADERS = [*default_headers, "credentials"]
 CORS_ALLOW_CREDENTIALS = True
-JWT_AUTH_SAMESITE = None
+JWT_AUTH_SAMESITE = "None"
 JWT_AUTH_SECURE = False
 
 


### PR DESCRIPTION
Для возможности работать с ref_token на http:localhost в настройках dev установили `JWT_AUTH_SECURE=False`